### PR TITLE
Fix issue with game only taking up bottom 1/4 of the window on Catalina

### DIFF
--- a/macosx/Resources/Quake II/Info.plist
+++ b/macosx/Resources/Quake II/Info.plist
@@ -107,5 +107,7 @@
 			</array>
 		</dict>
 	</array>
+    <key>NSHighResolutionCapable</key>
+    <false/>
 </dict>
 </plist>


### PR DESCRIPTION
When I fired up this port, yquake2 and ioquake3 on macOS 10.15 Catalina after upgrading, the game screen only took up the bottom 1/4 of the window 

Example:
<img width="1136" alt="Screen Shot 2019-10-08 at 10 45 20 PM" src="https://user-images.githubusercontent.com/502580/66688117-e679fc80-ec4a-11e9-877e-cb1a5f8f48b0.png">

After submitting an issue to ioquake3 one of the lead maintainers figured it out - a property in the Info.plist file needs to be set differently in Catalina. 

https://github.com/ioquake/ioq3/issues/422

I've verified that this port of Quake 2 has the issue and this plist tweak fixed it.